### PR TITLE
Fix 'freecad' package conflict, and object recompute issue.

### DIFF
--- a/OpenSCADHull.py
+++ b/OpenSCADHull.py
@@ -528,5 +528,5 @@ def makeHull(list, ex=False):
     else:
         ViewProviderMyGroup(hullObj.ViewObject)
     hullObj.Group = list
-    hullObj.recompute()
+    hullObj.recompute(True)
     return hullObj

--- a/freecad/OpenSCAD_Alt_Import/__init__.py
+++ b/freecad/OpenSCAD_Alt_Import/__init__.py
@@ -1,3 +1,2 @@
-import FreeCAD
-FreeCAD.addImportType("New Importer CSG (*.csg)","freecad.OpenSCAD_Alt_Import.importCSG")
-FreeCAD.addImportType("New Importer SCAD (*.scad)","freecad.OpenSCAD_Alt_Import.importCSG")
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/freecad/OpenSCAD_Alt_Import/init_gui.py
+++ b/freecad/OpenSCAD_Alt_Import/init_gui.py
@@ -1,0 +1,3 @@
+import FreeCAD
+FreeCAD.addImportType("New Importer CSG (*.csg)","freecad.OpenSCAD_Alt_Import.importCSG")
+FreeCAD.addImportType("New Importer SCAD (*.scad)","freecad.OpenSCAD_Alt_Import.importCSG")


### PR DESCRIPTION
Please check out the commit message for more details.

Some additional information about the object recomputation problem. The first recompute is triggered by checkObjectShape() in OpenSCADHull.py, and the second recompute is by processcsg() in importCSG.py.

Here is a trick to obtain the above call site information. Run the following command in console to increase log level.

```
App.setLogLevel('App', 3)
```

This command only needs to be run once. It will cause extra log to be printed out in console. Make sure you enable log output in console. Right click console, select `Options -> Display message types -> Log messages`.  Example message out when you import a csg file

```
...
21:15:10  1672.74 <App> OpenSCADHull.py(531)|Document.cpp(4128): recompute on touched hulltwocones1__1_#hull.Proxy
21:15:10  Hull Object Group : hull, ['cylinder', 'cylinder001']
21:15:10  Update Shape??
...
21:15:10  End Parser
21:15:10  [<Part::PartFeature>]
21:15:10  End processing CSG file
21:15:10  1672.75 <App> importCSG.py(162)|Document.cpp(3837): Recompute pass 0

```

To revert the log output to default, run `App.setLogLevel('App', 2)`

To find out more about FreeCAD's built-in logger, checkout the doc string of Python class `App.Logger`.