### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
 
   <maintainer email="keith@sloan-home.co.uk">Keith Sloan</maintainer>
 
-  <license file="LICENSE">GPL-2</license>
+  <license file="LICENSE">GPL-2.0-only</license>
 
   <url branch="master" type="repository">https://github.com/KeithSloan/OpenSCAD_Alt_Import</url>
 


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean GPL-2.0-or-later, in which case use that instead.
